### PR TITLE
Add new options to the download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ or by ID
 twitch-dl download 1418494769
 ```
 
+or all videos from a channel
+
+```
+twitch-dl download bananasaurus_rex --all
+```
+
 Download a clip by URL
 
 ```

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -9,3 +9,9 @@ the `TMP` environment variable, e.g.
 ```
 TMP=/my/tmp/path/ twitch-dl download 221837124
 ```
+
+You can also specify the `--tempdir` argument to the `download` command without having to modify your environment variables. For example:
+
+```
+twitch-dl download 221837124 --tempdir /my/tmp/path/
+```

--- a/docs/commands/clips.md
+++ b/docs/commands/clips.md
@@ -33,11 +33,6 @@ twitch-dl clips <channel_name> [FLAGS] [OPTIONS]
     <td class="code">-j, --json</td>
     <td>Show results as JSON. Ignores <code>--pager</code>.</td>
 </tr>
-
-<tr>
-    <td class="code">-d, --download</td>
-    <td>Download all videos in given period (in source quality)</td>
-</tr>
 </tbody>
 </table>
 

--- a/docs/commands/download.md
+++ b/docs/commands/download.md
@@ -35,8 +35,23 @@ twitch-dl download <videos> [FLAGS] [OPTIONS]
 </tr>
 
 <tr>
+    <td class="code">--skipall</td>
+    <td>Skip the current file if it already exists without prompting.</td>
+</tr>
+
+<tr>
     <td class="code">--overwrite</td>
     <td>Overwrite the target file if it already exists without prompting.</td>
+</tr>
+
+<tr>
+    <td class="code">-x, --all</td>
+    <td>Download all videos on the channel. Overrides all other arguments. Pass in the channel name as the &#x27;videos&#x27; argument.</td>
+</tr>
+
+<tr>
+    <td class="code">-y, --skip-latest</td>
+    <td>Skip downloading the latest video. Only makes sense with the --all flag.</td>
 </tr>
 </tbody>
 </table>
@@ -67,7 +82,7 @@ twitch-dl download <videos> [FLAGS] [OPTIONS]
 
 <tr>
     <td class="code">-q, --quality</td>
-    <td>Video quality, e.g. 720p. Set to &#x27;source&#x27; to get best quality.</td>
+    <td>Video quality, e.g. 720p30 or 720p60. Set to &#x27;source&#x27; to get best quality.</td>
 </tr>
 
 <tr>
@@ -88,6 +103,26 @@ twitch-dl download <videos> [FLAGS] [OPTIONS]
 <tr>
     <td class="code">-c, --chapter</td>
     <td>Download a single chapter of the video. Specify the chapter number or use the flag without a number to display a chapter select prompt.</td>
+</tr>
+
+<tr>
+    <td class="code">-t, --tempdir</td>
+    <td>Override the temp dir path.</td>
+</tr>
+
+<tr>
+    <td class="code">-d, --output-dir</td>
+    <td>Customize location of the output directory. Defaults to the current directory.</td>
+</tr>
+
+<tr>
+    <td class="code">-u, --execute-after</td>
+    <td>Run a CLI command after each file is downloaded and processed. In your command, use ^p for the absolute path to the file that was downloaded, and ^f for just the file name.</td>
+</tr>
+
+<tr>
+    <td class="code">-z, --execute-before</td>
+    <td>Run a CLI command before each file is downloaded. Return an exit code of 0 to indicate you want to download the file, or nonzero to indicate you want to skip the file. In your command, use ^p for the absolute path to the file that was downloaded, and ^f for just the file name.</td>
 </tr>
 </tbody>
 </table>

--- a/examples/s3_search.sh
+++ b/examples/s3_search.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Check if AWS CLI is installed
+if ! command -v aws &> /dev/null
+then
+    echo "AWS CLI not installed. Please install and configure it."
+    exit 2
+fi
+
+# Check for correct number of arguments
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <s3-bucket-name> <file-name>"
+    exit 2
+fi
+
+BUCKET=$1
+FILE=$2
+
+# Check if file exists in the S3 bucket
+if aws s3 ls "s3://$BUCKET/$FILE" > /dev/null; then
+    echo "File $FILE exists in bucket $BUCKET."
+    exit 1
+else
+    echo "File $FILE does not exist in bucket $BUCKET."
+    exit 0
+fi

--- a/examples/s3_upload_nuke.sh
+++ b/examples/s3_upload_nuke.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Check if AWS CLI is installed
+if ! command -v aws &> /dev/null
+then
+    echo "AWS CLI not installed. Please install and configure it."
+    exit 2
+fi
+
+# Check for correct number of arguments
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <s3-bucket-name> <file-name>"
+    exit 2
+fi
+
+BUCKET=$1
+FILE=$2
+
+# Upload the file to S3, then delete the local copy
+set -e
+aws s3 cp "${FILE}" "s3://$BUCKET/" --storage-class GLACIER
+rm -f "${FILE}"
+
+exit 0

--- a/twitchdl/commands/download.py
+++ b/twitchdl/commands/download.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 import httpx
 import m3u8
 import os
@@ -6,6 +7,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import shlex
 
 from os import path
 from pathlib import Path
@@ -16,7 +18,18 @@ from twitchdl import twitch, utils
 from twitchdl.download import download_file
 from twitchdl.exceptions import ConsoleError
 from twitchdl.http import download_all
-from twitchdl.output import print_out
+from twitchdl.output import print_err, print_out
+
+def _execute_download_command(file_path: str, command_template: str) -> bool:
+    print_out(f"file_path: {file_path}")
+    file_name = os.path.basename(file_path)
+    qfp = shlex.quote(str(file_path))
+    qfn = shlex.quote(file_name)
+    command = command_template.replace("^p", qfp).replace("^f", qfn)
+    
+    compl = subprocess.run(command, shell=True, check=False)
+    print_out(f"Executed command: {command}")
+    return compl.returncode == 0
 
 
 def _parse_playlists(playlists_m3u8):
@@ -101,7 +114,8 @@ def _video_target_filename(video, args):
     }
 
     try:
-        return args.output.format(**subs)
+        target = args.output.format(**subs)
+        return Path(args.output_dir, target) if args.output_dir else target
     except KeyError as e:
         supported = ", ".join(subs.keys())
         raise ConsoleError("Invalid key {} used in --output. Supported keys are: {}".format(e, supported))
@@ -131,7 +145,8 @@ def _clip_target_filename(clip, args):
     }
 
     try:
-        return args.output.format(**subs)
+        target = args.output.format(**subs)
+        return Path(args.output_dir, target) if args.output_dir else target
     except KeyError as e:
         supported = ", ".join(subs.keys())
         raise ConsoleError("Invalid key {} used in --output. Supported keys are: {}".format(e, supported))
@@ -157,17 +172,36 @@ def _get_vod_paths(playlist, start: Optional[int], end: Optional[int]) -> List[s
     return files
 
 
-def _crete_temp_dir(base_uri: str) -> str:
+def _crete_temp_dir(base_uri: str, args) -> str:
     """Create a temp dir to store downloads if it doesn't exist."""
     path = urlparse(base_uri).path.lstrip("/")
-    temp_dir = Path(tempfile.gettempdir(), "twitch-dl", path)
+    temp_dir = Path(args.tempdir if args.tempdir else tempfile.gettempdir(), "twitch-dl", path)
     temp_dir.mkdir(parents=True, exist_ok=True)
     return str(temp_dir)
 
+def _download_all_videos(channel_name, args):
+    print_out(f"<dim>Fetching all videos for channel: {channel_name}...</dim>")
+    total_count, video_generator = twitch.channel_videos_generator(channel_name, sys.maxsize, 'time', 'archive')
+    print_out(f"<dim>Found {total_count} videos to download...</dim>")
+
+    if args.skip_latest:
+        next(video_generator)  # Skip the latest video
+
+    for video in video_generator:
+        #Skip execution if the pre-execute command returns non-zero status
+        target_filename = _video_target_filename(video, args)
+        if not args.execute_before or (args.execute_before and _execute_download_command(target_filename, args.execute_before)):
+            _download_video(video['id'], args)
+        else:
+            print_out(f"<dim>Skipping video due to pre-execute returning nonzero: {video['id']}...</dim>")
 
 def download(args):
-    for video_id in args.videos:
-        download_one(video_id, args)
+    if args.all:
+        # Assuming the channel name is passed in args.videos[0]
+        _download_all_videos(args.videos[0], args)
+    else:
+        for video_id in args.videos:
+            download_one(video_id, args)
 
 
 def download_one(video: str, args):
@@ -278,6 +312,9 @@ def _download_clip(slug: str, args) -> None:
 
     print_out("Downloaded: <blue>{}</blue>".format(target))
 
+    if args.execute_after:
+        _execute_download_command(target, args.execute_after)
+
 
 def _download_video(video_id, args) -> None:
     if args.start and args.end and args.end <= args.start:
@@ -336,7 +373,7 @@ def _download_video(video_id, args) -> None:
     playlist = m3u8.loads(response.text)
 
     base_uri = re.sub("/[^/]+$", "/", playlist_uri)
-    target_dir = _crete_temp_dir(base_uri)
+    target_dir = _crete_temp_dir(base_uri, args)
     vod_paths = _get_vod_paths(playlist, start, end)
 
     # Save playlists for debugging purposes
@@ -380,6 +417,9 @@ def _download_video(video_id, args) -> None:
         shutil.rmtree(target_dir)
 
     print_out("\nDownloaded: <green>{}</green>".format(target))
+
+    if args.execute_after:
+        _execute_download_command(target, args.execute_after)
 
 
 def _determine_time_range(video_id, args):

--- a/twitchdl/console.py
+++ b/twitchdl/console.py
@@ -160,11 +160,6 @@ COMMANDS = [
                 "nargs": "?",
                 "const": 10,
             }),
-            (["-d", "--download"], {
-                "help": "Download all videos in given period (in source quality)",
-                "action": "store_true",
-                "default": False,
-            }),
         ],
     ),
     Command(
@@ -203,7 +198,7 @@ COMMANDS = [
                 "default": False,
             }),
             (["-q", "--quality"], {
-                "help": "Video quality, e.g. 720p. Set to 'source' to get best quality.",
+                "help": "Video quality, e.g. 720p30 or 720p60. Set to 'source' to get best quality.",
                 "type": str,
             }),
             (["-a", "--auth-token"], {
@@ -244,6 +239,36 @@ COMMANDS = [
                 "type": int,
                 "nargs": "?",
                 "const": 0
+            }),
+            (["-x", "--all"], {
+                "help": "Download all videos on the channel. Overrides all other arguments. Pass in the channel name as the 'videos' argument.",
+                "action": "store_true",
+                "default": False,
+            }),
+            (["-y", "--skip-latest"], {
+                "help": "Skip downloading the latest video. Only makes sense with the --all flag.",
+                "action": "store_true",
+                "default": False,
+            }),
+            (["-t", "--tempdir"], {
+                "help": "Override the temp dir path.",
+                "type": str,
+                "default": ""
+            }),
+            (["-d", "--output-dir"], {
+                "help": "Customize location of the output directory. Defaults to the current directory.",
+                "type": str,
+                "default": "."
+            }),
+            (["-u", "--execute-after"], {
+                "help": "Run a CLI command after each file is downloaded and processed. In your command, use ^p for the absolute path to the file that was downloaded, and ^f for just the file name. An example use case is in examples/s3_upload_nuke.sh in the GitHub repository.",
+                "type": str,
+                "default": None
+            }),
+            (["-z", "--execute-before"], {
+                "help": "Run a CLI command before each file is downloaded. Return an exit code of 0 to indicate you want to download the file, or nonzero to indicate you want to skip the file. In your command, use ^p for the absolute path to the file that was downloaded, and ^f for just the file name. An example use case is in examples/s3_search.sh in the GitHub repository.",
+                "type": str,
+                "default": None
             }),
         ],
     ),


### PR DESCRIPTION
Highlights:
--all: Download all videos on a channel
--execute-before and --execute-after: Run a command before and after downloading a file, optionally skipping the download when running --execute-before if the script returns non-zero

Other commands added to support my use case.

Basically, these changes (plus the new scripts in examples/) allow one to easily archive a Twitch channel's current VODs to any S3-compatible destination. There are lots of implementors of S3 protocol, not just AWS. For example, Scaleway, OVH and Wasabi all implement S3, and there are probably implementations for on-prem software like ownCloud too.

Combine this with a RAM disk (like Tmpdisk on MacOS) and you can download and upload all in memory, without wearing down your SSD with all the file I/O.

I'm PRing it here, because your fork is active, while upstream seems dead. Want to merge patches for a while, at least until the upstream works on twitch-dl again? :)